### PR TITLE
Update highlighter due to deprecation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-highlighter: pygments
+highlighter: rouge, 
 timezone: America/New_York
 encoding: utf-8
 title: Binghamton ACM

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-highlighter: rouge, 
+highlighter: rouge
 timezone: America/New_York
 encoding: utf-8
 title: Binghamton ACM


### PR DESCRIPTION
For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.